### PR TITLE
Makes git clone easier to highlight and copy. Removed broken clone link with backtick added `

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Quickly add material design icons to your application with this preview provider
 
 1. Install [Node.js](https://nodejs.org/en/)
 2. Run comand: ´npm install -g yo generator-code´
-3. Clone this proyect: ´git clone https://github.com/DeniferSantiago/mdi-vuetify-intellisense.git´
+3. Clone this project: 
+  ```
+  git clone https://github.com/DeniferSantiago/mdi-vuetify-intellisense.git
+  ```
 4. Open proyect with vs code
 5. Run command: ´npm install´ for get node_modules folder
 6. Explore and Contribute


### PR DESCRIPTION
triple clicking git clone area now should highlight the entire line.
Typo fix. proyect -> project